### PR TITLE
Ignore GA4React initialization errors

### DIFF
--- a/habhub-react-frontend/src/index.js
+++ b/habhub-react-frontend/src/index.js
@@ -17,7 +17,7 @@ const GA_UID = process.env.REACT_APP_GA_UID;
 const ga4react = new GA4React(GA_UID);
 
 (async () => {
-  await ga4react.initialize();
+  await ga4react.initialize().catch((err) => {});
 
   ReactDOM.render(
     <Provider store={store}>


### PR DESCRIPTION
⚠️ Untested change.

My ad blocker blocks Google Analytics. This causes the `GA4React` initialization to fail, which causes the whole app to fail to load and results in a blank page.

This change catches any errors thrown during initialization and silently ignores them.